### PR TITLE
Remove obsolete add_stars.sh

### DIFF
--- a/.ghuser.io.json
+++ b/.ghuser.io.json
@@ -1,4 +1,0 @@
-{
-  "_comment": "Repo metadata for ghuser.io. See https://github.com/AurelienLourot/ghuser.io/blob/master/docs/repo-settings.md",
-  "avatar_url": "https://www.burntfen.com/assets/img/project/endangered-languages.png"
-}

--- a/.ghuser.io.json
+++ b/.ghuser.io.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Repo metadata for ghuser.io. See https://github.com/AurelienLourot/ghuser.io/blob/master/docs/repo-settings.md",
+  "avatar_url": "https://www.burntfen.com/assets/img/project/endangered-languages.png"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ Please feel free to contribute in any way you can: by submitting links, by engag
 - Alphabetize your entry.
 - If a language entry for your specific tool does not exist, please create one.
 - Update the Table of Contents if you can. This can be done automatically with [`doctoc`](https://github.com/thlorenz/doctoc).
-- To add the GitHub Star badge, run `cd tooling; sh add_stars.sh`.
 - Check that your links work. We will automatically catch any broken links using TravisCI.
 
 If any of this is arduous, please open a PR with what you have and we can work together to make it fit.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Looking for resources for code languages? Take a look at [the awesome lists coll
 * [old](https://github.com/dativebase/old) - The Online Linguistic Database (OLD): software for linguistic fieldwork. http://www.onlinelinguisticdatabase.org.
 * [old-pyramid](https://github.com/dativebase/old-pyramid) - Online Linguistic Database migrated to the Pyramid framework.
 * [OmegaT-hfst-tokenizer](https://github.com/divvun/OmegaT-hfst-tokenizer) - OmegaT-hfst-tokenizer provides fst-based tokenisation in OmegaT.
-* [OpenDataKit](https://opendatakit.org/downloads/) Open Data Kit (ODK) is an open-source suite of tools that helps organizations author, field, and manage mobile data collection solutions
+* [OpenDataKit](https://opendatakit.org/software/) Open Data Kit (ODK) is an open-source suite of tools that helps organizations author, field, and manage mobile data collection solutions
 * [OpenNLP](https://github.com/apache/opennlp) - The Apache OpenNLP library is a machine learning based toolkit for the processing of natural language text. [Website](https://opennlp.apache.org).
 * [ops-devbox](https://github.com/sillsdev/ops-devbox) - Ansible playbook for a (linux) developer machine.
 * [panlex-tools](https://github.com/longnow/panlex-tools) - This package contains scripts to transform lexical resources into a format suitable for importing into PanLex. Documentation may be found at https://dev.panlex.org.
@@ -514,7 +514,7 @@ These corpora are useful for working with tools on endangered languages. Monolin
 ## Other OSS Organizations
 
 * [Giellatekno](http://giellatekno.uit.no/index.eng.html) - Giellatekno combines cutting-edge linguistic and computational research into the analysis of Saami and other morphologically-rich languages, with the development of practical applications. We focus on deep linguistic modeling and on highly efficient and robust computational analysis with a wide empirical coverage. They use svn for their code: all of it can be found [here](https://victorio.uit.no/langtech/trunk/langs/), sorted by language.
-* [LOWLANDS](https://bitbucket.org/lowlands/) - LOWLANDS – Parsing low-resource languages and domains http://ccc.ku.dk/research/lowlands/
+* [LOWLANDS](https://bitbucket.org/lowlands/) - LOWLANDS – Parsing low-resource languages and domains https://ccc.ku.dk/research/lowlands/
 * [LTRC: Language Technologies Research Center IIIT Hyderabad](http://ltrc.iiit.ac.in/) LTRC addresses the complex problem of understanding and processing natural languages in both speech and text mode. LTRC conducts research on both basic and applied aspects of language technology. It is the largest academic centre of speech and language technology in South Asia. LTRC carries out its work through four labs, which work in synergy with each other, as listed above.
 * [The Language Archive](https://tla.mpi.nl/tools/tla-tools/) Part of the MPI
 

--- a/tooling/add_stars.sh
+++ b/tooling/add_stars.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# Add GitHub stars if it doesn't exist
-sed -i "" '/GitHub stars/! s/^\* \[\(.*\)\](https:\/\/github.com\/\([^ )]*\))\(.*\)/* [\1 \![GitHub stars]\(https:\/\/img.shields.io\/github\/stars\/\2.svg\)]\(https:\/\/github.com\/\2\)\3/' README.md
-
-# TODO Make sure that description matches `...) - desc`. format
-# TODO Add periods on ends of descriptions
-# TODO Automatically get descriptions (requires major refactor)


### PR DESCRIPTION
Hi @RichardLitt, we know each other from https://github.com/RichardLitt/low-resource-languages/pull/140.

If I understood correctly you stopped using these star badges because they are often not resolved in time. 

I'm also using this opportunity to define an icon for this repo on ghuser.io, a project I'm working on for building **complete** GitHub profiles like http://ghuser.io/RichardLitt (this is supposed to list all repos you have ever touched on GitHub, sorted by relevance. And yes, the list is massive in your case!)

Of course feel free to decline that file if you don't like it, no problem :) 